### PR TITLE
Declare vueify transform in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,13 @@
     "vue-loader": "^3.0.3",
     "webpack": "^1.9.11"
   },
+  "browserify": {
+    "transform": [
+      [
+        "vueify"
+      ]
+    ]
+  },
   "scripts": {
     "dev": "webpack --watch",
     "build": "webpack --config webpack.build.js && webpack --config webpack.build.min.js"


### PR DESCRIPTION
Allow projects that use browerify instead of webpack to easily `require` components