### PR TITLE
Allow modal to be responsive

### DIFF
--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -5,8 +5,7 @@
     zoom:effect === 'zoom'"
     >
     <div class="modal-dialog" role="document"
-      v-style="width: width + 'px'
-      ">
+      v-style="width: widthOptional">
       <div class="modal-content">
         <content select=".modal-header">
           <div class="modal-header">
@@ -45,7 +44,7 @@ import EventListener from './utils/EventListener.js'
       },
       width: {
         type: Number,
-        default: 600
+        default: null
       },
       callback: {
         type: Function,
@@ -82,6 +81,14 @@ import EventListener from './utils/EventListener.js'
           }, 300)
         }
       }
+    },
+    computed: {
+      widthOptional: function() {
+        if(this.width !== null) {
+          return this.width + "px";
+        }
+        return null;
+      },
     },
     methods: {
       close() {


### PR DESCRIPTION
if no width prop is provided modal size defaults to 600px on >786px devices and full width on <768px devices (defaults specified in bootstrap css)