### PR TITLE
Fixed bugs while using slot in Modal

### DIFF
--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -8,16 +8,16 @@
     <div class="modal-dialog" role="document"
       v-bind:style="{'width': width + 'px'}">
       <div class="modal-content">
-        <slot select=".modal-header">
+        <slot name="modal-header">
           <div class="modal-header">
             <button type="button" class="close" @click="close"><span>&times;</span></button>
             <h4 class="modal-title" >{{title}}</h4>
           </div>
         </slot>
-        <slot select=".modal-body">
+        <slot name="modal-body">
           <div class="modal-body"></div>
         </slot>
-        <slot select=".modal-footer">
+        <slot name="modal-footer">
           <div class="modal-footer">
             <button type="button" class="btn btn-default" @click="close">Close</button>
             <button type="button" class="btn btn-primary" @click="callback">Save changes</button>


### PR DESCRIPTION
按照vuejs.org的文档，修复了在src/Modal.vue中对slot的错误使用。

尽量保持vue-strap文档中对modal的使用方式
可以如下使用：

```
<modal :show.sync="modalShown" title="modalTitle">
  <div slot="modal-body">I am body</div>
  <div slot="modal-footer" class="modal-footer">
    <button type="button" class="btn btn-default" @click="close">Close</button>
    <button type="button" class="btn btn-primary" @click="saveChange">Save changes</button>
  </div>
</modal>
```

原来的bug在于：无论在<modal></modal>中写什么，都会被复制3次，原因是对`slot`的使用错误。