### PR TITLE
Fixes initial carousel render

### DIFF
--- a/src/Slider.vue
+++ b/src/Slider.vue
@@ -22,7 +22,7 @@
       {
         if (this.$parent.$children[c].$el == this.$el)
         {
-            this.index= c;
+            this.index = parseInt(c,10);
             break;
         }
       }


### PR DESCRIPTION
Sets the initial index for slider to an integer instead of a string. Now the first slide gets the active class on load.