### PR TITLE
Fixed bug, when the page don't have scrollbar, calculation error in getScrollBarWidth.js.

### DIFF
--- a/src/utils/getScrollBarWidth.js
+++ b/src/utils/getScrollBarWidth.js
@@ -1,4 +1,7 @@
 export default ()=> {
+  if (document.documentElement.scrollHeight <= document.documentElement.clientHeight) {
+    return 0
+  }
   let inner = document.createElement('p')
   inner.style.width = '100%'
   inner.style.height = '200px'


### PR DESCRIPTION
e.g.
```
<template>
  <button class="btn btn-primary"
    @click="fadeModal = true">
    Fade modal
  </button>
  <modal title="Fade Modal" :show.sync="fadeModal" effect="fade" :width="400">
    <div slot="modal-body" class="modal-body">...</div>
  </modal>

  <p style="word-break: break-all;">12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890</p>
</template>
```