### PR TITLE
Add prop to close dropdown on selection for non multiple selects

### DIFF
--- a/src/Select.vue
+++ b/src/Select.vue
@@ -51,6 +51,10 @@
       limit: {
         type: Number,
         default: 1024
+      },
+      closeOnSelect: { // only works when multiple==false
+        type: Boolean,
+        default: false
       }
     },
     ready(){
@@ -122,6 +126,9 @@
             this.value.$remove(v)
         }else{
           this.value=v
+          if(this.closeOnSelect) {
+            this.toggleDropdown();
+          }
         }
 
       },


### PR DESCRIPTION
I added a prop for the select component that if set to true will close the select dropdown after an option is selected. The prop is only relevant if multiple is set to false.