### PR TITLE
Allow raw HTML in Tabs headers

### DIFF
--- a/src/Tabset.vue
+++ b/src/Tabset.vue
@@ -11,7 +11,7 @@
                 @click.prevent="handleTabListClick($index, r)"
                 :disabled="r.disabled"
             >
-                <a href="#">{{r.header}}</a>
+                <a href="#">{{{r.header}}}</a>
             </li>
      </ul>
 


### PR DESCRIPTION
Allows placing html tags inside tabs headers, i. e. an icon:
````html
<tabs>
    <tab :header='"<i class=\"fa fa-user\"></i> Profile"'>
        tab content
    </tab>
</tabs>
````
