### PR TITLE
Make it able to overwrite modal's close() method

### DIFF
--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -20,7 +20,7 @@
         </slot>
         <slot name="modal-footer">
           <div class="modal-footer">
-            <button type="button" class="btn btn-default" @click="close">Close</button>
+            <button type="button" class="btn btn-default" @click="onClose">Close</button>
             <button type="button" class="btn btn-primary" @click="callback">Save changes</button>
           </div>
         </slot>
@@ -51,6 +51,10 @@ import EventListener from './utils/EventListener.js'
         type: Function,
         default() {}
       },
+      onClose: {
+        type: Function,
+        default() {this.close()}
+      }
       effect: {
         type: String,
         default: null
@@ -83,7 +87,7 @@ import EventListener from './utils/EventListener.js'
           }
           if (this.backdrop) {
             this._blurModalContentEvent = EventListener.listen(this.$el, 'click', (e)=> {
-              if (e.target === el) this.show = false
+              if (e.target === el) this.onClose()
             })
           }
         } else {


### PR DESCRIPTION
I needed to be able to overwrite modal's `close()` method so i decided to give it a shot. 

I'm not an experienced javascript developer and that's my first day with vue.js so please forgive me if that PR is ridiculous or something is not right with it. I'm gonna do my best to fix any possible issues or bad patterns.

#### Background:
I'm creating a component which needs to keep vue-strap modal `show` state in the flux store. There was no way to update the `show` store state to `false` after closing the modal so i decided to make that PR.