### PR TITLE
Select & Option refactor

### DIFF
--- a/docs/example/selectDocs.vue
+++ b/docs/example/selectDocs.vue
@@ -66,12 +66,12 @@ Select data : {{custom.join(', ')}}
 Select data : {{arr}}
         </pre>
       </p>
-      <v-select :value.sync="arr" :options="fruitOptions" :search="true">
+      <v-select :value.sync="arr" :options="fruitOptions" :search="true" :close-on-select="true">
       </v-select>
 
       <hr />
       <h4>Automatically close array driven selects</h4>
-      <p>Using the property :close-on-select="true" array driven selects will auto-close after selecting an entry. Only works for non-multiple selects.</p>
+      <p>Using the property :close-on-select="true" array driven selects will auto-close after selecting an entry.</p>
       <v-select :value.sync="arr2" :options="fruitOptions" :close-on-select="true">
       </v-select>
     </div>
@@ -172,11 +172,11 @@ fruitOptions = [
     data() {
       return {
         fruitOptions: [
-          {value:'apple', label:'Apple'},
-          {value:'banana', label:'Banana'},
-          {value:'cherry', label:'Cherry'},
-          {value:'orange', label:'Orange'},
-          {value:'grape', label:'Grape'},
+          {value:'Apple', label:'Apple'},
+          {value:'Banana', label:'Banana'},
+          {value:'Cherry', label:'Cherry'},
+          {value:'Orange', label:'Orange'},
+          {value:'Grape', label:'Grape'},
         ],
         arr: [],
         arr2: [],

--- a/src/Option.vue
+++ b/src/Option.vue
@@ -21,11 +21,7 @@
     },
     computed: {
       chosen() {
-        if(this.$parent.multiple){
-          return this.$parent.value.indexOf(this.value) !== -1 ? true : false  
-        }
-        return this.$parent.value==this.value
-        
+        return this.$parent.value.indexOf(this.value) !== -1
       }
     },
     methods: {
@@ -35,7 +31,7 @@
           const index = parent.value.indexOf(this.value)
           index === -1 ? parent.value.push(this.value) : parent.value.splice(index, 1)
         } else {
-          parent.value=this.value;
+          parent.value = [this.value]
           parent.show = false
         }
       }
@@ -43,7 +39,7 @@
   }
 </script>
 
-<style>
+<style scoped>
   a span.check-mark {
     position: absolute;
     display: inline-block;

--- a/src/Select.vue
+++ b/src/Select.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="btn-group" v-bind:class="{open:show}">
-    <button v-el:btn type="button" class="btn btn-default dropdown-toggle" 
+  <div class="btn-group" v-bind:class="{open: show}">
+    <button v-el:btn type="button" class="btn btn-default dropdown-toggle"
       @click="toggleDropdown"
-      @blur="show = (search ? show:false)"
+      @blur="show = (search ? show : false)"
     >
-      <span class="placeholder" v-show="showPlaceholder">{{placeholder}}</span>
-      <span class="content">{{ selectedItems }}</span>
+      <span class="btn-placeholder" v-show="showPlaceholder">{{placeholder}}</span>
+      <span class="btn-content">{{ selectedItems }}</span>
       <span class="caret"></span>
     </button>
     <ul class="dropdown-menu">
@@ -57,9 +57,19 @@
         default: false
       }
     },
-    ready(){
-      if(this.multiple){
-        this.value=[]
+    ready() {
+      if (this.value.constructor !== Array) {
+        if (this.value.length === 0) {
+          this.value = []
+        } else {
+          this.value = [this.value]
+        }
+      } else {
+        if (!this.multiple && this.value.length > 1) {
+          this.value = this.value.slice(0, 1)
+        } else if (this.multiple && this.value.length > this.limit) {
+          this.value = this.value.slice(0, this.limit)
+        }
       }
     },
     data() {
@@ -71,74 +81,43 @@
     },
     computed: {
       selectedItems() {
-        if (!this.multiple)
-        {
-          if(!this.options.length) {
-            for (var c of this.$children) {
-              if (c.value == this.value) {
-                return c.$els.v.innerText
-              }
-            }
-          } else {
-            for(var i=0; i<this.options.length; i++) {
-              if(this.options[i].value === this.value) {
-                return this.options[i].label;
-              }
-            }
+        let foundItems = []
+        if (this.value.length) {
+          for (let item in this.value) {
+            foundItems.push(this.value[item])
           }
-          return ""
-        }
-        else
-        {
-          if (!this.options.length){
-			var r=[]
-            for(var c of this.$children){
-              if(this.value.indexOf(c.value)!==-1){
-                  r.push(c.$els.v.innerText)
-              }
-            }
-            return r.join(',');
-          }else{
-			// we were given bunch of options, so pluck them out to display
-			var foundItems = [];
-            for (var item of this.options){
-            	if (this.value.indexOf(item.value) !== -1)
-                	foundItems.push(item.label);
-			}
-            return foundItems.join(', ');
-          }
+          return foundItems.join(', ')
         }
       },
       showPlaceholder() {
-      	return this.multiple ? this.value.length <= 0 : (typeof this.value==='undefined' || this.value=='');
+        return this.value.length === 0
       }
     },
     watch: {
       value(val) {
-        let timeout
-        if (timeout) clearTimeout(timeout)
         if (val.length > this.limit) {
           this.showNotify = true
           this.value.pop()
-          timeout = setTimeout(()=> this.showNotify = false, 1000)
+          setTimeout(() => this.showNotify = false, 1000)
         }
       }
     },
     methods: {
       select(v) {
-        if(this.multiple!=false){
-          var index = this.value.indexOf(v);
-          if (index === -1)
-            this.value.push(v);
-          else
-            this.value.$remove(v)
-        }else{
-          this.value=v
-          if(this.closeOnSelect) {
-            this.toggleDropdown();
+          if (this.value.indexOf(v) === -1) {
+            if (this.multiple) {
+              this.value.push(v)
+            } else {
+              this.value = [v]
+            }
+          } else {
+            if (this.multiple) {
+              this.value.$remove(v)
+            }
           }
-        }
-
+          if (this.closeOnSelect) {
+            this.toggleDropdown()
+          }
       },
       toggleDropdown() {
         this.show = !this.show
@@ -146,21 +125,22 @@
     }
   }
 </script>
-<style>
-.bs_searchbox {
-  padding: 4px 8px;
-}
-.btn-group .dropdown-menu .notify {
-  position: absolute;
-  bottom: 5px;
-  width: 96%;
-  margin: 0 2%;
-  min-height: 26px;
-  padding: 3px 5px;
-  background: #f5f5f5;
-  border: 1px solid #e3e3e3;
-  box-shadow: inset 0 1px 1px rgba(0,0,0,.05);
-   pointer-events: none;
-  opacity: .9;
-}
+
+<style scoped>
+  .bs-searchbox {
+    padding: 4px 8px;
+  }
+  .btn-group .dropdown-menu .notify {
+    position: absolute;
+    bottom: 5px;
+    width: 96%;
+    margin: 0 2%;
+    min-height: 26px;
+    padding: 3px 5px;
+    background: #f5f5f5;
+    border: 1px solid #e3e3e3;
+    box-shadow: inset 0 1px 1px rgba(0,0,0,.05);
+     pointer-events: none;
+    opacity: .9;
+  }
 </style>


### PR DESCRIPTION
- Allow defining initial values for selection
- Using scoped styles to avoid CSS selection conflicts
- Consistently using an array (with conversion of a string value to an array internally)
- Renamed CSS "placeholder" and "content" to "btn-placeholder" and "btn-content" to avoid conflicts with common CSS classes
- Coding style cleanup for consistency
- Simplification of selectedItems due to using Array consistently
- Allow closeOnSelect also for multiple selections
- Fix of CSS class bs_searchbox to bs-searchbox