### PR TITLE
Update property name to match parent

### DIFF
--- a/src/Tab.vue
+++ b/src/Tab.vue
@@ -27,7 +27,7 @@
     },
     computed: {
       show() {
-        return (this.$parent.activeIndex == this.index);
+        return (this.$parent.active == this.index);
       },
       transition() {
         return this.$parent.effect


### PR DESCRIPTION
This resolves an issue introduced in my last pull request to add a property for active tab.

https://github.com/yuche/vue-strap/pull/104