### PR TITLE
Add coercion prop option when using Vue > 1.0.12

### DIFF
--- a/src/Accordion.vue
+++ b/src/Accordion.vue
@@ -5,10 +5,13 @@
 </template>
 
 <script>
+import coerceBoolean from './utils/coerceBoolean.js'
+
   export default {
     props: {
       oneAtATime: {
         type: Boolean,
+        coerce: coerceBoolean,
         default: false
       }
     },

--- a/src/Alert.vue
+++ b/src/Alert.vue
@@ -22,6 +22,8 @@
 </template>
 
 <script>
+import coerceBoolean from './utils/coerceBoolean.js'
+
   export default {
     props: {
       type: {
@@ -29,10 +31,12 @@
       },
       dismissable: {
         type: Boolean,
+        coerce: coerceBoolean,
         default: false,
       },
       show: {
         type: Boolean,
+        coerce: coerceBoolean,
         default: true,
         twoWay: true
       },

--- a/src/Aside.vue
+++ b/src/Aside.vue
@@ -24,10 +24,13 @@
 <script>
 import EventListener from './utils/EventListener.js'
 import getScrollBarWidth from './utils/getScrollBarWidth.js'
+import coerceBoolean from './utils/coerceBoolean.js'
+
   export default {
     props: {
       show: {
         type: Boolean,
+        coerce: coerceBoolean,
         require: true,
         twoWay: true
       },

--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -22,14 +22,18 @@
 
 <script>
 import EventListener from './utils/EventListener.js'
+import coerceBoolean from './utils/coerceBoolean.js'
+
   export default {
     props: {
       indicators: {
         type: Boolean,
+        coerce: coerceBoolean,
         default: true
       },
       controls: {
         type: Boolean,
+        coerce: coerceBoolean,
         default: true
       },
       interval: {

--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -32,6 +32,7 @@
 <script>
 import getScrollBarWidth from './utils/getScrollBarWidth.js'
 import EventListener from './utils/EventListener.js'
+import coerceBoolean from './utils/coerceBoolean.js'
 
   export default {
     props: {
@@ -42,6 +43,7 @@ import EventListener from './utils/EventListener.js'
       show: {
         require: true,
         type: Boolean,
+        coerce: coerceBoolean,
         twoWay: true
       },
       width: {
@@ -57,14 +59,17 @@ import EventListener from './utils/EventListener.js'
       },
       backdrop: {
         type: Boolean,
+        coerce: coerceBoolean,
         default: true
       },
       large: {
         type: Boolean,
+        coerce: coerceBoolean,
         default: false
       },
       small: {
         type: Boolean,
+        coerce: coerceBoolean,
         default: false
       }
     },

--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -21,10 +21,13 @@
 </template>
 
 <script>
+import coerceBoolean from './utils/coerceBoolean.js'
+
   export default {
     props: {
       isOpen: {
         type: Boolean,
+        coerce: coerceBoolean,
         default: false
       },
       header: {

--- a/src/Progressbar.vue
+++ b/src/Progressbar.vue
@@ -15,6 +15,8 @@
 </template>
 
 <script>
+import coerceBoolean from './utils/coerceBoolean.js'
+
   export default {
     props: {
       now: {
@@ -23,6 +25,7 @@
       },
       label: {
         type: Boolean,
+        coerce: coerceBoolean,
         default: false
       },
       type: {
@@ -30,10 +33,12 @@
       },
       striped: {
         type: Boolean,
+        coerce: coerceBoolean,
         default: false
       },
       animated: {
         type: Boolean,
+        coerce: coerceBoolean,
         default: false
       }
     }

--- a/src/Select.vue
+++ b/src/Select.vue
@@ -27,6 +27,8 @@
 </template>
 
 <script>
+import coerceBoolean from './utils/coerceBoolean.js'
+
   export default {
     props: {
       options: {
@@ -42,10 +44,12 @@
       },
       multiple: {
         type: Boolean,
+        coerce: coerceBoolean,
         default: false
       },
       search: { // Allow searching (only works when options are provided)
       	type: Boolean,
+        coerce: coerceBoolean,
       	default: false
       },
       limit: {
@@ -54,6 +58,7 @@
       },
       closeOnSelect: { // only works when multiple==false
         type: Boolean,
+        coerce: coerceBoolean,
         default: false
       }
     },

--- a/src/Tab.vue
+++ b/src/Tab.vue
@@ -9,6 +9,8 @@
 </template>
 
 <script>
+import coerceBoolean from './utils/coerceBoolean.js'
+
   export default {
     props: {
       header: {
@@ -16,6 +18,7 @@
       },
       disabled: {
         type: Boolean,
+        coerce: coerceBoolean,
         default: false
       }
     },

--- a/src/Typeahead.vue
+++ b/src/Typeahead.vue
@@ -18,7 +18,7 @@
       <a @mousedown.prevent="hit" @mousemove="setActive($index)">
         <partial :name="templateName"></partial>
       </a>
-    </li> 
+    </li>
   </ul>
 </div>
 
@@ -26,6 +26,8 @@
 
 <script>
 import callAjax from './utils/callAjax.js'
+import coerceBoolean from './utils/coerceBoolean.js'
+
 const typeahead = {
     created() {
       this.items = this.primitiveData
@@ -56,6 +58,7 @@ const typeahead = {
       },
       matchCase: {
         type: Boolean,
+        coerce: coerceBoolean,
         default: false
       },
       onHit: {

--- a/src/checkboxBtn.vue
+++ b/src/checkboxBtn.vue
@@ -20,6 +20,8 @@
 </template>
 
 <script>
+import coerceBoolean from './utils/coerceBoolean.js'
+
   export default {
     props: {
       value: {
@@ -27,6 +29,7 @@
       },
       checked: {
         type: Boolean,
+        coerce: coerceBoolean,
         default: false
       }
     },

--- a/src/popoverMixins.js
+++ b/src/popoverMixins.js
@@ -1,4 +1,6 @@
 import EventListener from './utils/EventListener.js'
+import coerceBoolean from './utils/coerceBoolean.js'
+
 const PopoverMixin = {
   props: {
     trigger: {
@@ -17,6 +19,7 @@ const PopoverMixin = {
     },
     header: {
       type: Boolean,
+      coerce: coerceBoolean,
       default: true
     },
     placement: {

--- a/src/radioBtn.vue
+++ b/src/radioBtn.vue
@@ -21,6 +21,8 @@
 </template>
 
 <script>
+import coerceBoolean from './utils/coerceBoolean.js'
+
   export default {
     props: {
       value: {
@@ -28,6 +30,7 @@
       },
       checked: {
         type: Boolean,
+        coerce: coerceBoolean,
         default: false
       }
     },

--- a/src/utils/coerceBoolean.js
+++ b/src/utils/coerceBoolean.js
@@ -1,0 +1,7 @@
+// Attempt to convert a string value to a Boolean. Otherwise, return the value
+// without modification so Vue can throw a warning.
+export default (val) => (typeof val !== "string" ? val :
+  val === "true" ? true :
+  val === "false" ? false :
+  val === "null" ? false :
+  val === "undefined" ? false : val)


### PR DESCRIPTION
Allow simpler notation for Boolean attributes in markup. Instead of
(in Jade):

```jade
    alert(v-bind:dismissable="true") message
```

You can now just type:

```jade
    alert(dismissable="true") message
```

If the value of the property is not "true", "false", "null" or "undefined"
then it will simply be passed as-is so that Vue can throw a warning.

If the version of Vue is older than 1.0.12 then the coercion simply won't
happen and you will have to specify props using the longer notation.

I made a short example for tinkering with here: [Coerce Boolean Example][0]

  [0]: http://codepen.io/sirlancelot/pen/pgqeqG?editors=1010