### PR TITLE
remove debugging console.log

### DIFF
--- a/src/Typeahead.vue
+++ b/src/Typeahead.vue
@@ -125,7 +125,6 @@ const typeahead = {
         return this.current === index
       },
       hit(e) {
-        console.log("e", e, "e.targetVm", e.targetVM);
         e.preventDefault()
         this.onHit(this.items[this.current], this);
       },


### PR DESCRIPTION
I think, the `console.log` in `Typehead.vue` is just for debugging...?

It is also in v1.0.7.
https://github.com/yuche/vue-strap/blob/v1.0.7/src/Typeahead.vue#L128