### PR TITLE
Correction to case insensitive comparisons in typeahead

### DIFF
--- a/src/Typeahead.vue
+++ b/src/Typeahead.vue
@@ -85,8 +85,9 @@ const typeahead = {
       primitiveData() {
         if (this.data) {
           return this.data.filter(value=> {
-            value = this.matchCase ? value : value.toLowerCase()
-            return value.indexOf(this.query) !== -1
+            value = this.matchCase ? value : value.toLowerCase();
+            var query = this.matchCase ? this.query : this.query.toLowerCase();
+	          return value.indexOf(query) !== -1;
           }).slice(0, this.limit)
         }
       }

--- a/src/Typeahead.vue
+++ b/src/Typeahead.vue
@@ -83,10 +83,12 @@ const typeahead = {
     },
     computed: {
       primitiveData() {
+        var _this = this;
+        
         if (this.data) {
           return this.data.filter(value=> {
             value = this.matchCase ? value : value.toLowerCase();
-            var query = this.matchCase ? this.query : this.query.toLowerCase();
+            var query = this.matchCase ? _this.query : _this.query.toLowerCase();
             return value.indexOf(query) !== -1;
           }).slice(0, this.limit)
         }

--- a/src/Typeahead.vue
+++ b/src/Typeahead.vue
@@ -87,7 +87,7 @@ const typeahead = {
           return this.data.filter(value=> {
             value = this.matchCase ? value : value.toLowerCase();
             var query = this.matchCase ? this.query : this.query.toLowerCase();
-	          return value.indexOf(query) !== -1;
+            return value.indexOf(query) !== -1;
           }).slice(0, this.limit)
         }
       }


### PR DESCRIPTION
Currently the value being compared is forced to lowercase, but the query string against which it is being compared isn't. this means that matches are possible only to lowercase input (this can be seen currently on the US states example on the documentation site). This fix forces both value and query string to lowercase (for case insensitive comparisons only) allowing upper, lower and mixed case searches to match when appropriate.