### PR TITLE
Add reset button to datepicker component

### DIFF
--- a/docs/example/datepickerDocs.vue
+++ b/docs/example/datepickerDocs.vue
@@ -8,7 +8,7 @@ Selected date is: {{new Date(value).toString().slice(0, -23)}}
         </pre>
       </p>
       <datepicker v-ref:dp :value.sync="value" :disabled-days-of-Week="disabled"
-      :format="format.toString()"></datepicker>
+      :format="format.toString()" :show-reset-button="reset"></datepicker>
       <h4>Disabled days of week</h4>
 
       <v-select multiple :value.sync="disabled">
@@ -29,12 +29,16 @@ Selected date is: {{new Date(value).toString().slice(0, -23)}}
         <v-option value="MMM/dd/yyyy">MMM/dd/yyyy</v-option>
         <v-option value="MMMM/dd/yyyy">MMMM/dd/yyyy</v-option>
       </v-select>
+
+      <h4>Reset button</h4>
+      <label><input type="checkbox" v-model="reset" @click="x"> toggle reset button</label>
     </div>
     <pre><code class="language-markup"><script type="language-mark-up">
 <datepicker
   :value.sync="value"
   :disabled-days-of-Week="disabled"
-  :format="format">
+  :format="format"
+  :show-reset-button="reset">
 </datepicker>
 
 <select multiple :value.sync="disabled" size=5>
@@ -90,6 +94,13 @@ Selected date is: {{new Date(value).toString().slice(0, -23)}}
           <td>Days of the week that should be disabled. Values are 0 (Sunday) to 6 (Saturday).
              Multiple values should be comma-separated.</td>
         </tr>
+        <tr>
+          <td>showResetButton</td>
+          <td><code>Boolean</code></td>
+          <td>false</td>
+          <td>If <strong>true</strong> shows an &times; shaped button to clear the selected date.
+            Usefull in forms where date entry is optional.</td>
+        </tr>
       </tbody>
     </table>
   </div>
@@ -109,7 +120,8 @@ Selected date is: {{new Date(value).toString().slice(0, -23)}}
       return {
         disabled: [],
         value: 'Oct/06/2015',
-        format: ['MMM/dd/yyyy']
+        format: ['MMM/dd/yyyy'],
+        reset: true
       }
     },
     watch: {

--- a/src/Datepicker.vue
+++ b/src/Datepicker.vue
@@ -1,4 +1,8 @@
 <style>
+  input.datepicker-input.with-reset-button {
+    padding-right: 25px;
+  }
+
   div.datepicker > button.close {
     position: absolute;
     top: calc(50% - 13px);
@@ -17,7 +21,7 @@
 
 <template>
   <div class="datepicker">
-    <input class="form-control datepicker-input" type="text"
+    <input class="form-control datepicker-input" :class="{'with-reset-button': showResetButton}" type="text"
         v-bind:style="{width:width}"
         @click="inputClick"
         v-model="value"/>

--- a/src/Datepicker.vue
+++ b/src/Datepicker.vue
@@ -1,9 +1,28 @@
+<style>
+  div.datepicker > button.close {
+    position: absolute;
+    top: calc(50% - 13px);
+    right: 10px;
+  }
+
+  div.datepicker > button.close {
+    outline: none;
+  }
+
+  div.datepicker > button.close:focus {
+    opacity: .2;
+  }
+</style>
+
 <template>
   <div class="datepicker">
     <input class="form-control datepicker-input" type="text"
         v-bind:style="{width:width}"
         @click="inputClick"
         v-model="value"/>
+    <button v-if="showResetButton" type="button" class="close" @click="value = ''">
+      <span>&times;</span>
+    </button>
     <div class="datepicker-popup" v-show="displayDayView">
       <div class="datepicker-inner">
         <div class="datepicker-body">
@@ -84,6 +103,10 @@ export default {
     width: {
       type: String,
       default: '200px'
+    },
+    showResetButton: {
+      type: Boolean,
+      default: false
     }
   },
   data() {

--- a/src/Datepicker.vue
+++ b/src/Datepicker.vue
@@ -7,6 +7,7 @@
 
   div.datepicker > button.close {
     outline: none;
+    z-index: 2;
   }
 
   div.datepicker > button.close:focus {


### PR DESCRIPTION
Adds an option to show a reset button inside the datepickers text input field that clears the entered date. Useful for forms where the date field is optional, i.e. search forms.