### PR TITLE
Bower version mismatch

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "vue-strap",
-  "version": "0.1.0",
   "homepage": "https://github.com/yuche/vue-strap",
   "authors": [
     "yuche <i@yuche.me>"


### PR DESCRIPTION
Bower detects and reports a difference between the semver git tag and the version in this bower.json file. One approach would be to ensure that the bower.json file is updated for each release - but that's a pain. So a better approach is simply to remove the version number from it and allow the semver git tag to be used without contradiction.