### PR TITLE
add toggle event for dropdown

### DIFF
--- a/src/Dropdown.vue
+++ b/src/Dropdown.vue
@@ -27,6 +27,14 @@
     },
     beforeDestroy() {
       if (this._closeEvent) this._closeEvent.remove()
+    },
+    props: {
+      dropdownId: String
+    },
+    events: {
+      toggleDropdown(dropdownId) {
+        if(dropdownId === this.dropdownId) this.$el.classList.toggle('open')
+      }
     }
   }
 </script>


### PR DESCRIPTION
I found it's hard close the dropdown list when click one element in the list.
After added this event, we can easily close the list by add one row: this.$broadcast('toggleDropdown', 'idOfYourDropdown');
user need to add an id for each dropdown, if he want to use the event, since we may have more than one dropdown in the page.

Moreover, if user want to open the list by click another button, he can also use this code. But remember to stop propagation of that button.