### PR TITLE
Allow typeahead queries to be matched strictly to suggestion starts

### DIFF
--- a/docs/example/typeaheadDocs.vue
+++ b/docs/example/typeaheadDocs.vue
@@ -132,6 +132,12 @@ new Vue {
           <td>Case sensitive for suggestions.</td>
         </tr>
         <tr>
+          <td>match-start</td>
+          <td><code>Boolean</code></td>
+          <td><code>false</code></td>
+          <td>Match only against start of suggestions. E.g. if true, "a" matches "ab" but not "ba".</td>
+        </tr>
+        <tr>
           <td>on-hit</td>
           <td><code>Function</code></td>
           <td></td>

--- a/src/Typeahead.vue
+++ b/src/Typeahead.vue
@@ -61,6 +61,11 @@ const typeahead = {
         coerce: coerceBoolean,
         default: false
       },
+      matchStart: {
+        type: Boolean,
+        coerce: coerceBoolean,
+        default: false
+      },
       onHit: {
         type: Function,
         default(items) {
@@ -87,7 +92,7 @@ const typeahead = {
           return this.data.filter(value=> {
             value = this.matchCase ? value : value.toLowerCase();
             var query = this.matchCase ? this.query : this.query.toLowerCase();
-            return value.indexOf(query) !== -1;
+            return this.matchStart ? value.indexOf(query) === 0 : value.indexOf(query) !== -1;
           }).slice(0, this.limit)
         }
       }


### PR DESCRIPTION
This PR adds a "match-start" prop to allow for more intuitive matches. For example, when entering a US state with limit = 8, but match-start not set, i.e. the current default state, entering "O" will yield Arizona, California, Colorado, Connecticut, Florida, Georgia, Idaho and Illinois, which are probably not what is intended.

With the match-start prop enabled, it will match Oregon, Oklahoma and Ohio instead. Yay!