### PR TITLE
make the 'now' property of the progressbar a twoway binding

### DIFF
--- a/src/Progressbar.vue
+++ b/src/Progressbar.vue
@@ -21,7 +21,8 @@ import coerceBoolean from './utils/coerceBoolean.js'
     props: {
       now: {
         type: Number,
-        require: true
+        require: true,
+        twoWay: true
       },
       label: {
         type: Boolean,


### PR DESCRIPTION
I was sad to see that the binding of the 'now' property was not twoWay and thus would block any progress on the progress bar (and defeat the purposes of the component itself), I made this small change to make it possible :) 