### PR TITLE
fix(Tabset.vue): Correct the wrong use of camelCase name for "v-el:"

### DIFF
--- a/src/Tabset.vue
+++ b/src/Tabset.vue
@@ -16,7 +16,7 @@
      </ul>
 
      <!-- Tab panes -->
-     <div class="tab-content" v-el:tabContent>
+     <div class="tab-content" v-el:tab-content>
         <slot></slot>
      </div>
   </div>


### PR DESCRIPTION
The warning in vue@1.0.17 is annoying.

fix Issue #133 