### PR TITLE
moved @click in radioBtn from input to label, same for checkboxBtn

### DIFF
--- a/src/checkboxBtn.vue
+++ b/src/checkboxBtn.vue
@@ -1,5 +1,6 @@
 <template>
   <label class="btn"
+  @click="handleClick"
   v-bind:class="{
     'active':checked,
     'btn-success':type == 'success',
@@ -12,7 +13,6 @@
 
     <input type="checkbox" autocomplete="off"
     :checked="checked"
-    @click="handleClick"
     />
 
     <slot></slot>

--- a/src/radioBtn.vue
+++ b/src/radioBtn.vue
@@ -1,5 +1,6 @@
 <template>
   <label class="btn"
+  @click="handleClick"
   v-bind:class="{
     'active':active,
     'btn-success':type == 'success',
@@ -12,7 +13,6 @@
 
     <input type="radio" autocomplete="off"
       :checked="checked"
-      @click="handleClick"
     />
 
     <slot></slot>


### PR DESCRIPTION
Since Bootstrap hides the input, the target of clicks is the label. This results in the value not updating in some bootstrap themes. Should solve this issue:
https://github.com/yuche/vue-strap/issues/38