### PR TITLE
Typehead: allow to get query value

### DIFF
--- a/src/Dropdown.vue
+++ b/src/Dropdown.vue
@@ -24,6 +24,12 @@
       this._closeEvent = EventListener.listen(window, 'click', (e)=> {
         if (!el.contains(e.target)) el.classList.remove('open')
       })
+      const targets = document.querySelectorAll('.btn-dropdown .dropdown-menu a')
+      for( let i = 0; i < targets.length; i++) {
+        targets[i].addEventListener('click', e => {
+          el.classList.remove('open')
+        })
+      }
     },
     beforeDestroy() {
       if (this._closeEvent) this._closeEvent.remove()

--- a/src/Typeahead.vue
+++ b/src/Typeahead.vue
@@ -39,6 +39,10 @@ const typeahead = {
       data: {
         type: Array
       },
+      query: {
+        type: String,
+        twoWay: true
+      },
       limit: {
         type: Number,
         default: 8
@@ -47,10 +51,10 @@ const typeahead = {
         type: String
       },
       template: {
-        type:String
+        type: String
       },
       templateName: {
-        type:String,
+        type: String,
         default: 'default'
       },
       key: {
@@ -74,7 +78,6 @@ const typeahead = {
     },
     data() {
       return {
-        query: '',
         showDropdown: false,
         noResults: true,
         current: 0,


### PR DESCRIPTION
Make the `query` value a twoWay property so it can be retrieved to the user

This allow to easy get the value, instead of writing a method

```vue
<typehead
  :query.sync="model.property">
</typehead>
```

instead of 

```vue
<typehead
  :on-hit="updateValue">
</typehead>

<script>
methods: {
  updateValue: function (val, typeh) {
    typeh.query = val
    this.model.property = val
  }
}
</script>
```

**UPDATE**

Allow to close dropdown menu on selection of an item