### PR TITLE
fixed TypeError: scope.value.indexOf is not a function when Select.value is a number

### DIFF
--- a/src/Select.vue
+++ b/src/Select.vue
@@ -17,7 +17,7 @@
         <li v-for="option in options | filterBy searchText " v-bind:id="option.value" style="position:relative">
           <a @mousedown.prevent="select(option.value)" style="cursor:pointer">
             {{ option.label }}
-            <span class="glyphicon glyphicon-ok check-mark" v-show="value.indexOf(option.value) !== -1"></span>
+            <span class="glyphicon glyphicon-ok check-mark" v-show="isSelected(option.value)"></span>
           </a>
         </li>
       </template>
@@ -131,6 +131,13 @@ import coerceBoolean from './utils/coerceBoolean.js'
           if (this.closeOnSelect) {
             this.toggleDropdown()
           }
+      },
+      isSelected(v) {
+        if (this.value.constructor !== Array) {
+          return this.value == v
+        } else {
+          return this.value.indexOf(v) !== -1
+        }
       },
       toggleDropdown() {
         this.show = !this.show


### PR DESCRIPTION
in `Select.vue`

`<span class="glyphicon glyphicon-ok check-mark" v-show="value.indexOf(option.value) !== -1"></span>`

will run before `ready()`, so value has not be converted to Array and also can not use `indexOf` method(maybe string can, but still a wrong way).