### PR TITLE
Fixed issue #112 and #55 and added slot tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
   },
   "browserify": {
     "transform": [
+    [
+       "babelify", { "presets": ["es2015"] }
+    ],
       [
         "vueify"
       ]

--- a/src/Aside.vue
+++ b/src/Aside.vue
@@ -11,7 +11,11 @@
       <div class="aside-content">
         <div class="aside-header">
           <button type="button" class="close" @click='close'><span>&times;</span></button>
-          <h4 class="aside-title">{{header}}</h4>
+          <h4 class="aside-title">   
+          <slot name="header"> 
+            {{ header }}
+          </slot>
+          </h4>
         </div>
         <div class="aside-body">
           <slot></slot>

--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -12,7 +12,7 @@
         <slot name="modal-header">
           <div class="modal-header">
             <button type="button" class="close" @click="close"><span>&times;</span></button>
-            <h4 class="modal-title" >{{title}}</h4>
+            <h4 class="modal-title" > <slot name="title"{{title}}></slot></h4>
           </div>
         </slot>
         <slot name="modal-body">

--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -12,7 +12,11 @@
         <slot name="modal-header">
           <div class="modal-header">
             <button type="button" class="close" @click="close"><span>&times;</span></button>
-            <h4 class="modal-title" > <slot name="title"{{title}}></slot></h4>
+            <h4 class="modal-title" > 
+              <slot name="title">
+                {{title}}
+              </slot>
+            </h4>
           </div>
         </slot>
         <slot name="modal-body">

--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -4,7 +4,9 @@
       <h4 class="panel-title">
         <a class="accordion-toggle"
           @click="toggleIsOpen()">
-           {{ header }}
+          <slot name="header"> 
+            {{ header }}
+          </slot>
         </a>
       </h4>
     </div>

--- a/src/Popover.vue
+++ b/src/Popover.vue
@@ -14,9 +14,15 @@
     v-show="show"
     :transition="effect">
       <div class="arrow"></div>
-      <h3 class="popover-title" v-show="title"> <slot name="title">{{title}} </slot> </h3>
+      <h3 class="popover-title" v-show="title"> 
+          <slot name="title">
+            {{title}} 
+          </slot> 
+      </h3>
       <div class="popover-content">
-       <slot name="content"> {{{content}}} </slot> 
+        <slot name="content"> 
+            {{{content}}} 
+        </slot> 
       </div>
   </div>
 </template>

--- a/src/Popover.vue
+++ b/src/Popover.vue
@@ -14,9 +14,9 @@
     v-show="show"
     :transition="effect">
       <div class="arrow"></div>
-      <h3 class="popover-title" v-show="title">{{title}}</h3>
+      <h3 class="popover-title" v-show="title"> <slot name="title">{{title}} </slot> </h3>
       <div class="popover-content">
-        {{{content}}}
+       <slot name="content"> {{{content}}} </slot> 
       </div>
   </div>
 </template>

--- a/src/Select.vue
+++ b/src/Select.vue
@@ -22,7 +22,8 @@
         </li>
       </template>
       <slot v-else></slot>
-      <div class="notify" v-show="showNotify" transition="fadein">Limit reached ({{limit}} items max).</div>
+      <div class="notify" v-show="showNotify" transition="fadein">Limit reached ({{limit}} items max).
+      </div>
     </ul>
   </div>
 </template>

--- a/src/Tabset.vue
+++ b/src/Tabset.vue
@@ -11,12 +11,16 @@
                 @click.prevent="handleTabListClick($index, r)"
                 :disabled="r.disabled"
             >
-                <a href="#">{{{r.header}}}</a>
+                <a href="#">  
+                    <slot name="header"> 
+                      {{{r.header}}}
+                  </slot> 
+                </a>
             </li>
      </ul>
 
      <!-- Tab panes -->
-     <div class="tab-content" v-el:tabContent>
+     <div class="tab-content" v-el:tab-content>
         <slot></slot>
      </div>
   </div>

--- a/src/Tooltip.vue
+++ b/src/Tooltip.vue
@@ -16,8 +16,10 @@
     role="tooltip">
     <div class="tooltip-arrow"></div>
     <div class="tooltip-inner">
-      {{{content}}}
-    </div>
+       <slot name="content">
+        {{{content}}}
+      </slot> 
+   </div>
   </div>
 </template>
 


### PR DESCRIPTION
TL;DR I fixed #112 #55  #28 #13 (all are same issue) correctly and issue #133  and added some slot tags where i found appropriate

I ran into  the issue yesterday and didn't like the hack original issuer ( #28  ) used. so i traced its cause and fixed it.
 the problem was that vue-strap does not specify `transform: babelify` for browersify-transforms even though index,js and main,js are es6 code.
So I added the code. and it works.

Also I fixed a typo in tabSet.vue #133 
I changed ` <div class="tab-content" v-el:tabContent>` to `<div class="tab-content" v-el:tab-content>`

Other changes I did was to wrap `{{header}}`, `{{title}}` and `{{{ content}}}` in a `<slot>` tag so by default code will work as it used to, but now we can use `<slot>` to pass html around instead of using attributes.
