### PR TITLE
updated 'main' to point to index.js instead of dist/vue-strap.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vue-strap",
   "version": "1.0.8",
   "description": "Bootstrap components built with Vue.js",
-  "main": "dist/vue-strap.js",
+  "main": "src/index.js",
   "repository": {
     "type": "git",
     "url": "yuche/vue-strap"


### PR DESCRIPTION
#### currently( after pr#156 is merged),

     require('vue-strap').modal //fails
     import {modal} from 'vue-strap' //fails

     require('vue-strap/src/main.js').modal //fails
     require('vue-strap/src/index.js').modal // works

#### after this commit

     require('vue-strap').modal //works
     import {modal} from 'vue-strap' //works

     require('vue-strap/src/main.js').modal //fails
     require('vue-strap/src/index.js').modal // works



## Resoning behind the change (it is just a one line change):
The problem is two-fold

 1. `main` originally pointed to `src/main.js` but was changed to `dist/vue-strap.js` to fix a problem #157 . 
according to https://github.com/yuche/vue-strap/issues/13#issuecomment-163075376
so naturally, `main` should be updated to `src/main.js` 


 2. `require('vue-strap').modal` works when main refers to index.js instead of main.js. I am using laravel-elixir-vueify with browserify. imo, main.js is redundant. but I am not the one who wrote it and hece I don't its actual purpose.

after debugging with chrome, I found that `main.js` returns an esModule (I have no idea what it means) and affix, aside, modal etc are getters and setters of the object.

On other hand, `index.js` returns an object containing affix, aside, modal etc as a Vue component object, which is what we need.

hence, i propose to change `main` to `src/index.js`

PS: have i written too much for a one line change??