### PR TITLE
Datepicker support for non-US date formats

### DIFF
--- a/docs/example/datepickerDocs.vue
+++ b/docs/example/datepickerDocs.vue
@@ -28,6 +28,8 @@ Selected date is: {{new Date(value).toString().slice(0, -23)}}
         <v-option value="yyyy.MM.dd">yyyy.MM.dd</v-option>
         <v-option value="MMM/dd/yyyy">MMM/dd/yyyy</v-option>
         <v-option value="MMMM/dd/yyyy">MMMM/dd/yyyy</v-option>
+        <v-option value="dd/MM/yyyy">dd/MM/yyyy</v-option>
+        <v-option value="dd-MM-yyyy">dd-MM-yyyy</v-option>
       </v-select>
 
       <h4>Reset button</h4>
@@ -56,6 +58,8 @@ Selected date is: {{new Date(value).toString().slice(0, -23)}}
   <v-option value="yyyy.MM.dd">yyyy.MM.dd</v-option>
   <v-option value="MMM/dd/yyyy">MMM/dd/yyyy</v-option>
   <v-option value="MMMM/dd/yyyy">MMMM/dd/yyyy</v-option>
+  <v-option value="dd/MM/yyyy">dd/MM/yyyy</v-option>
+  <v-option value="dd-MM-yyyy">dd-MM-yyyy</v-option>
 </select>
     </script></code></pre>
     <h2>Option</h2>

--- a/src/Datepicker.vue
+++ b/src/Datepicker.vue
@@ -252,6 +252,9 @@ export default {
       .replace(/d/g, day)
     },
     parse(str) {
+      if (this.format == 'dd-MM-yyyy' || this.format == 'dd/MM/yyyy') {
+        str = str.substring(3,5)+'-'+str.substring(0,2)+'-'+str.substring(6,10);
+      }
       const date = new Date(str)
       return isNaN(date.getFullYear()) ? null : date
     },

--- a/src/Datepicker.vue
+++ b/src/Datepicker.vue
@@ -252,7 +252,7 @@ export default {
       .replace(/d/g, day)
     },
     parse(str) {
-      if (this.format == 'dd-MM-yyyy' || this.format == 'dd/MM/yyyy') {
+      if (str.length == 10 && (this.format == 'dd-MM-yyyy' || this.format == 'dd/MM/yyyy')) {
         str = str.substring(3,5)+'-'+str.substring(0,2)+'-'+str.substring(6,10);
       }
       const date = new Date(str)


### PR DESCRIPTION
Datepicker doesn't play nicely with the date formats dd-MM-yyyy and dd/MM/yyyy commonly used outside of North America.

The constructor for the Date class can't tell these apart from MM-dd-yyyy and MM/dd/yyyy and treats them as though they were the latter leading to some minor bugs in highlighting the active date and a ton of Vue warnings if the date chosen is later than the 12th.

This PR catches these date formats and flips them round to ensure that the Date object is instantiated correctly. The Docs have also been updated to show these formats in action.