### PR TITLE
fix: close dropdown on dropdown link click

### DIFF
--- a/src/Dropdown.vue
+++ b/src/Dropdown.vue
@@ -22,7 +22,7 @@
         toggle.addEventListener('click', this.toggleDropdown)
       }
       this._closeEvent = EventListener.listen(window, 'click', (e)=> {
-        if (!el.contains(e.target)) el.classList.remove('open')
+        if (!el.contains(e.target) || e.target.nodeName.toLowerCase() == 'a') el.classList.remove('open')
       })
     },
     beforeDestroy() {


### PR DESCRIPTION
the dropdown remained open if a **link in the dropdown** was clicked.
this fix takes care of that faulty behaviour.