### PR TITLE
explicitly accept json in ajax requests

### DIFF
--- a/src/utils/callAjax.js
+++ b/src/utils/callAjax.js
@@ -8,7 +8,7 @@ export default (url, callback)=> {
             }
         }
     }
-    httpRequest.setRequestHeader("Accept", "application/json")
     httpRequest.open('GET', url)
+    httpRequest.setRequestHeader("Accept", "application/json")
     httpRequest.send()
 }

--- a/src/utils/callAjax.js
+++ b/src/utils/callAjax.js
@@ -8,6 +8,7 @@ export default (url, callback)=> {
             }
         }
     }
+    httpRequest.setRequestHeader("Accept", "application/json")
     httpRequest.open('GET', url)
     httpRequest.send()
 }


### PR DESCRIPTION
The ajax request is parsing the result as JSON, however this isn't being set in the headers. Firefox adds default headers for text/html, text/xml etc.

This means that some frameworks like Laravel, Umbraco etc start to automatically return the data as XML, breaking the typeahead data parsing.