### PR TITLE
Change main.js in package.json to point to the dist folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vue-strap",
   "version": "1.0.10",
   "description": "Bootstrap components built with Vue.js",
-  "main": "src/index.js",
+  "main": "dist/vue-strap.js",
   "repository": {
     "type": "git",
     "url": "yuche/vue-strap"


### PR DESCRIPTION
Revert #158  which made projects using vue-strap do a build to vue-strap, which to me is not correct. Using the dist folder means projects will use the built version of vue-strap and will not need loaders for sass or even vue.