### PR TITLE
Bump version in package.json to 1.0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-strap",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Bootstrap components built with Vue.js",
   "main": "dist/vue-strap.js",
   "repository": {


### PR DESCRIPTION
Forgot to bump the version in package.json, so npm wont pick up the change to the main property.