### PR TITLE
Fix Aside Documentation.

### DIFF
--- a/docs/example/asideDocs.vue
+++ b/docs/example/asideDocs.vue
@@ -45,17 +45,17 @@ if (talk === cheap){
 class="btn btn-success btn-lg"
 @click="showRight = true">Show Aside on right</button>
 
-<sidebar :show.sync="showRight" placement="right" header="Title" :width="350">
+<aside :show.sync="showRight" placement="right" header="Title" :width="350">
 ...
-</sidebar>
+</aside>
 
 <button
 class="btn btn-danger btn-lg"
 @click="showLeft = true">Show Aside on left</button>
 
-<sidebar :show.sync="showLeft" placement="left" header="Title" :width="350">
+<aside :show.sync="showLeft" placement="left" header="Title" :width="350">
 ...
-</sidebar></script></code></pre>
+</aside></script></code></pre>
 
     <h2>Options</h2>
     <table class="table table-bordered">


### PR DESCRIPTION
While the rest of the code is correct, the code enclosed within the pre tags that is visible to the user for the Vue Strap documentation is misleading. It originally read as "sidebar", when it should have been aside.

The markup located at https://yuche.github.io/vue-strap/#aside:

```
<sidebar :show.sync="showRight" placement="right" header="Title" :width="350">

</sidebar>
```
