### PR TITLE
Fix v-select (issue #211)

### DIFF
--- a/src/Select.vue
+++ b/src/Select.vue
@@ -94,6 +94,9 @@ import coerceBoolean from './utils/coerceBoolean.js'
     computed: {
       selectedItems() {
         let foundItems = []
+        if (this.value.constructor !== Array) {
+          return [this.value];
+        }
         if (this.value.length) {
           for (var item of this.value) {
           	if (this.options.length ===0)


### PR DESCRIPTION
This should fix issue #211 which reports an error for v-select.

The this.value in selectedItems() can be an Array or something else. Both cases should be handled differently.