### PR TITLE
add trigger options for popover : none & contextmenu

### DIFF
--- a/docs/example/popoverDocs.vue
+++ b/docs/example/popoverDocs.vue
@@ -28,15 +28,28 @@
         <button class="btn btn-default ">Popover on bottom</button>
       </popover>
       <hr>
-      <h4>Triger</h4>
+      <h4>Trigger</h4>
       <p>
         <popover effect="scale" title="Title" content="Lorem ipsum dolor sit amet" placement="top" trigger="hover">
           <button class="btn btn-default ">Mouseenter</button>
         </popover>
       </p>
+      <p>
       <popover effect="scale" title="Title" content="Lorem ipsum dolor sit amet" placement="bottom" trigger="focus">
         <input type="text" class="form-control" placeholder="Focus">
       </popover>
+      </p>
+      <p>
+      <popover effect="scale" title="Title" content="Lorem ipsum dolor sit amet" placement="bottom" trigger="contextmenu">
+        <input type="text" class="form-control" placeholder="ContextMenu (right-click)">
+      </popover>
+      </p>
+      <p>
+        <popover effect="scale" title="Title" content="Lorem ipsum dolor sit amet" placement="top" trigger="none" v-ref:notrigger>
+          <input type="text" class="form-control" placeholder="Triggered by an external event (in this case, the button)">
+        </popover>
+        <button class="btn btn-default" v-on:click="doPopoverToggle">Trigger the popover</button>
+      </p>
     </div>
     <doc-code language="markup">
       <popover effect="fade" placement="bottom" title="Title"
@@ -49,7 +62,9 @@
         <p>trigger</p>
         <p><code>String</code>, one of <code>click</code>
         <code>focus</code>
-        <code>hover</code></p>
+        <code>hover</code>
+        <code>contextmenu</code>
+        <code>none</code></p>
         <p><code>click</code></p>
         <p>How the popover is triggered.</p>
       </div>
@@ -107,6 +122,11 @@ export default {
     return {
       title: 'Title',
       text: 'Lorem ipsum dolor sit amet'
+    }
+  },
+  methods: {
+    doPopoverToggle: function (event) {
+      this.$refs.notrigger.toggle()
     }
   }
 }

--- a/src/popoverMixins.js
+++ b/src/popoverMixins.js
@@ -43,8 +43,28 @@ export default {
   ready () {
     if (!this.$els.popover) return console.error('Couldn\'t find popover v-el in your component that uses popoverMixin.')
     const triger = this.$els.trigger.children[0]
-    let events = this.trigger === 'hover' ? ['mouseleave', 'mouseenter'] : this.trigger === 'focus' ? ['blur', 'focus'] : ['click']
-    $(triger).on(events, () => this.toggle(events[1]))
+    if (this.trigger) {
+      switch (this.trigger) {
+        case 'none':
+          break
+        case 'hover':
+          $(triger).on(['mouseleave', 'mouseenter'], () => this.toggle())
+          break
+        case 'focus':
+          $(triger).on(['blur', 'focus'], () => this.toggle())
+          break
+        case 'contextmenu':
+          $(triger).on(['contextmenu'], (event) => {
+            event.preventDefault()
+            this.toggle()
+          })
+          break
+        case 'click':
+        default:
+          $(triger).on(['click'], () => this.toggle())
+          break
+      }
+    }
 
     const popover = this.$els.popover
     switch (this.placement) {


### PR DESCRIPTION
Hi 
i was trying to use vue-strap components in my project but found myself somewhat blocked by the choice of triggering event (only click, hover & focus)

so i added contextmenu (my actual need, right clicking in an input field or a button) (which also required to prevent default event propagation) and none so that people might do whatever they need

please let me known if you require changes before accepting the pull request

thanks
David