### PR TITLE
enable number value while using input。

### DIFF
--- a/src/Input.vue
+++ b/src/Input.vue
@@ -47,6 +47,7 @@
 <script>
 import coerceBoolean from './utils/coerceBoolean.js'
 import coerceNumber from './utils/coerceNumber.js'
+import coerceString from './utils/coerceString.js'
 import translations from './translations.js'
 import $ from './utils/NodeList.js'
 
@@ -55,6 +56,7 @@ export default {
     value: {
       twoWay: true,
       type: String,
+      coerce: coerceString,
       default: ''
     },
     match: {

--- a/src/utils/coerceString.js
+++ b/src/utils/coerceString.js
@@ -1,0 +1,2 @@
+// Attempt to convert a string/number value to string.
+export default (val) => (val + '')


### PR DESCRIPTION
enable number value while using input。
in last version the input component only support for String value 。
add coerceString to coerce value to String
－－－－－－－－－－－－－－－－－－－－－－－
原来的input value值只支持String 格式的字符串，添加了一个coerceString.js 将原值转换成String