### PR TITLE
fix multiple select bug

### DIFF
--- a/src/Select.vue
+++ b/src/Select.vue
@@ -27,7 +27,7 @@
         <li v-for="option in options | filterBy searchValue" :id="option[optionsValue]||option">
           <a @mousedown.prevent="select(option[optionsValue],option)">
             <span v-html="option[optionsLabel]||option"></span>
-            <span class="glyphicon glyphicon-ok check-mark" v-show="isSelected(option[optionsValue]||option)"></span>
+            <span class="glyphicon glyphicon-ok check-mark" v-show="isSelected(option[optionsValue])"></span>
           </a>
         </li>
       </template>


### PR DESCRIPTION
hi!

I found something wrong in multiple select component, about set the selected status.

if 'value'  = 0 or = false, etc. It can't be selected. 👀 ⬇️

In 'Select.vue' file,

```html
  <span class="glyphicon glyphicon-ok check-mark" v-show="isSelected(option[optionsValue] || option)"></span>
```

this `option[optionsValue] || option` will return 'option', and then.

In this method, will return false.

```js
isSelected (v) {
   return this.values.indexOf(v) > -1
}
```

so! I remove the '|| option'.  Because we would not care the argument of 'indexOf()', it will automatically be 'string'.