### PR TITLE
Updated typeaheadDocs to show actual example template code

### DIFF
--- a/docs/example/typeaheadDocs.vue
+++ b/docs/example/typeaheadDocs.vue
@@ -71,9 +71,8 @@
         data() {
           return {
             USstate: ['Alabama', 'Alaska', 'Arizona',...],
-            asynchronous: '{{formatted_address}}',
-            customTemplate: '<img width="18px" height="18px" v-attr="src:avatar_url"/>' +
-            '<span>{{login}}</span>'
+            asyncTemplate: '{{ item.formatted_address }}',
+            githubTemplate: '<img width="18px" height="18px" :src="item.avatar_url"/> <span>{{item.login}}</span>'
           }
         },
         methods: {


### PR DESCRIPTION
I put the `asyncTemplate` and the `githubTemplate` code into the `doc-code` block in typeaheadDocs. The different template parameters were a bit confusing to me at first because they didn't correspond to the actual sample JS given. Hopefully this will help someone else figure things out quicker :)