### PR TITLE
Typo prevents the menu slide animation ;)

### DIFF
--- a/src/Aside.vue
+++ b/src/Aside.vue
@@ -1,5 +1,5 @@
 <template>
-  <transition :name="'side' + this.placement">
+  <transition :name="'slide' + this.placement">
     <div class="aside" v-if="show" :style="{width:width+'px'}" :class="placement">
       <div class="aside-dialog">
         <div class="aside-content">


### PR DESCRIPTION
Also it seems I need to use .slideleft-enter-active instead of .slideleft-enter to see the slide in animation (otherwise I see only the slide out).