### PR TITLE
v2 fixed docs modal example

### DIFF
--- a/docs/example/modalDocs.vue
+++ b/docs/example/modalDocs.vue
@@ -2,7 +2,7 @@
   <doc-section id="modal" name="Modal">
     <div class="bs-example">
       <button class="btn btn-default" @click="showModal = true">Show modal</button>
-      <modal title="Modal title" v-model="showModal">
+      <modal title="Modal title" v-model="showModal" @ok="showModal = false">
         <div slot="modal-header" class="modal-header">
           <h4 class="modal-title">Modal <b>Title</b></h4>
         </div>
@@ -14,7 +14,7 @@
           proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
       </modal>
       <button class="btn btn-success" @click="fadeModal = true">Fade modal</button>
-      <modal title="Fade Modal" :value="fadeModal" @cancel="fadeModal = false" effect="fade" width="800">
+      <modal title="Fade Modal" :value="fadeModal" @ok="fadeModal = false" @cancel="fadeModal = false" effect="fade" width="800">
           Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
           tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
           quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
@@ -23,7 +23,7 @@
           proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
       </modal>
       <button class="btn btn-primary" @click="zoomModal = true">Zoom modal</button>
-      <modal title="Zoom Modal" :value="zoomModal" @ok="zoomModal = false" effect="zoom" width="400">
+      <modal title="Zoom Modal" :value="zoomModal" @ok="zoomModal = false" @cancel="zoomModal = false" effect="zoom" width="400">
           Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
           tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
           quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
@@ -32,7 +32,7 @@
           proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
       </modal>
       <button class="btn btn-default" @click="showCustomModal = true">Show custom modal</button>
-      <modal :value="showCustomModal" @cancel="showCustomModel = false" effect="fade" width="50%">
+      <modal :value="showCustomModal" @ok="showCustomModel = false" @cancel="showCustomModel = false" effect="fade" width="50%">
         <div slot="modal-header" class="modal-header">
           <h4 class="modal-title"><i>Custom</i> <code>Modal</code> <b>Title</b></h4>
         </div>
@@ -48,7 +48,7 @@
         </div>
       </modal>
       <button class="btn btn-warning" @click="largeModal = true">Large modal</button>
-      <modal title="Large Modal" :value="largeModal" @cancel="largeModal = false" large>
+      <modal title="Large Modal" :value="largeModal" @ok="largeModal = false" @cancel="largeModal = false" large>
           <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
           tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
           quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
@@ -69,7 +69,7 @@
           proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
       </modal>
       <button class="btn btn-danger" @click="smallModal = true">Small modal</button>
-      <modal title="Small Modal" :value="smallModal" @cancel="smallModal = false" small>
+      <modal title="Small Modal" :value="smallModal" @ok="smallModal = false" @cancel="smallModal = false" small>
           Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
           tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
           quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo

--- a/docs/example/modalDocs.vue
+++ b/docs/example/modalDocs.vue
@@ -103,77 +103,77 @@
           &lt;button type="button" class="btn btn-success" @click="saveMethod">Custom Save&lt;/button>
         &lt;/div>
       &lt;/modal>
-  </doc-code>
-  <doc-table>
-    <div>
-      <p>backdrop</p>
-      <p><code>Boolean</code></p>
-      <p><code>true</code></p>
-      <p>Enables/disables closing the modal by clicking on the backdrop.</p>
-    </div>
-    <div>
-      <p>callback</p>
-      <p><code>Function</code></p>
-      <p></p>
-      <p>A callback Function when you click the modal primary button.</p>
-    </div>
-    <div>
-      <p>cancel-text</p>
-      <p><code>String</code></p>
-      <p>Close</p>
-      <p>Text for cancel button</p>
-    </div>
-    <div>
-      <p>effect</p>
-      <p><code>String</code></p>
-      <p></p>
-      <p>set the name of the effect to use on modal, like fade or zoom</p>
-    </div>
-    <div>
-      <p>large</p>
-      <p><code>Boolean</code></p>
-      <p><code>false</code></p>
-      <p>Large modal (see boostrap's documentation for .modal-lg)</p>
-    </div>
-    <div>
-      <p>ok-text</p>
-      <p><code>String</code></p>
-      <p>Save changes</p>
-      <p>Text for OK button</p>
-    </div>
-    <div>
-      <p>small</p>
-      <p><code>Boolean</code></p>
-      <p><code>false</code></p>
-      <p>Small modal (see boostrap's documentation for .modal-sm)</p>
-    </div>
-    <div>
-      <p>title</p>
-      <p><code>String</code></p>
-      <p></p>
-      <p>Title of the modal component.</p>
-    </div>
-    <div>
-      <p>value</p>
-      <p><code>Boolean</code></p>
-      <p></p>
-      <p>true if modal need to be shown, note the Modal has no intenal state</p>
-    </div>
-    <div>
-      <p>width</p>
-      <p><code>Number, String or null</code></p>
-      <p><code>null</code></p>
-      <p>Pass a Number in pixels or a String with relational sizes ( e.g. '80%' or '5em' ). If null, the modal will be responsive per bootstrap's default.</p>
-    </div>
-  </doc-table>
-  <h2>Usage</h2>
-  <p>
-    If you just need a simple modal, you can use the <code>title</code> prop and the default footer. However, if you
-    need to put custom HTML or a custom footer, you can override the header or footer block by using
-    <code>&lt;div slot="modal-title" class="modal-title"&gt;...&lt;/div&gt;</code> and
-    <code>&lt;div slot="modal-footer" class="modal-footer"&gt;...&lt;/div&gt;</code>.
-  </p>
-  </div>
+    </doc-code>
+    <doc-table>
+      <div>
+        <p>backdrop</p>
+        <p><code>Boolean</code></p>
+        <p><code>true</code></p>
+        <p>Enables/disables closing the modal by clicking on the backdrop.</p>
+      </div>
+      <div>
+        <p>callback</p>
+        <p><code>Function</code></p>
+        <p></p>
+        <p>A callback Function when you click the modal primary button.</p>
+      </div>
+      <div>
+        <p>cancel-text</p>
+        <p><code>String</code></p>
+        <p>Close</p>
+        <p>Text for cancel button</p>
+      </div>
+      <div>
+        <p>effect</p>
+        <p><code>String</code></p>
+        <p></p>
+        <p>set the name of the effect to use on modal, like fade or zoom</p>
+      </div>
+      <div>
+        <p>large</p>
+        <p><code>Boolean</code></p>
+        <p><code>false</code></p>
+        <p>Large modal (see boostrap's documentation for .modal-lg)</p>
+      </div>
+      <div>
+        <p>ok-text</p>
+        <p><code>String</code></p>
+        <p>Save changes</p>
+        <p>Text for OK button</p>
+      </div>
+      <div>
+        <p>small</p>
+        <p><code>Boolean</code></p>
+        <p><code>false</code></p>
+        <p>Small modal (see boostrap's documentation for .modal-sm)</p>
+      </div>
+      <div>
+        <p>title</p>
+        <p><code>String</code></p>
+        <p></p>
+        <p>Title of the modal component.</p>
+      </div>
+      <div>
+        <p>value</p>
+        <p><code>Boolean</code></p>
+        <p></p>
+        <p>true if modal need to be shown, note the Modal has no intenal state</p>
+      </div>
+      <div>
+        <p>width</p>
+        <p><code>Number, String or null</code></p>
+        <p><code>null</code></p>
+        <p>Pass a Number in pixels or a String with relational sizes ( e.g. '80%' or '5em' ). If null, the modal will be responsive per bootstrap's default.</p>
+      </div>
+    </doc-table>
+    <h2>Usage</h2>
+    <p>
+      If you just need a simple modal, you can use the <code>title</code> prop and the default footer. However, if you
+      need to put custom HTML or a custom footer, you can override the header or footer block by using
+      <code>&lt;div slot="modal-title" class="modal-title"&gt;...&lt;/div&gt;</code> and
+      <code>&lt;div slot="modal-footer" class="modal-footer"&gt;...&lt;/div&gt;</code>.
+    </p>
+  </doc-section>
 </template>
 
 <script>


### PR DESCRIPTION
fixed main docs modal example.

1. indent and closing `doc-section` tag.
2. can't close example modal

