### PR TITLE
Optional Panel Header

### DIFF
--- a/docs/bodyDocs.vue
+++ b/docs/bodyDocs.vue
@@ -29,6 +29,7 @@
             <input-docs></input-docs>
             <modal-docs></modal-docs>
             <navbar-docs></navbar-docs>
+            <panel-docs></panel-docs>
             <popover-docs></popover-docs>
             <progressbar-docs></progressbar-docs>
             <radio-docs></radio-docs>
@@ -81,6 +82,7 @@ import gettingStarted from './example/gettingStarted.vue'
 import inputDocs from './example/inputDocs.vue'
 import modalDocs from './example/modalDocs.vue'
 import navbarDocs from './example/navbarDocs.vue'
+import panelDocs from './example/panelDocs.vue'
 import popoverDocs from './example/popoverDocs.vue'
 import progressbarDocs from './example/progressbarDocs.vue'
 import radioDocs from './example/radioDocs.vue'
@@ -109,6 +111,7 @@ export default {
     inputDocs,
     modalDocs,
     navbarDocs,
+    panelDocs,
     popoverDocs,
     progressbarDocs,
     radioDocs,

--- a/docs/example/panelDocs.vue
+++ b/docs/example/panelDocs.vue
@@ -1,0 +1,94 @@
+<template>
+  <doc-section id="panel" name="Panel">
+    <div class="bs-example">
+      <p><v-select :options="types" clear-button v-model="type" placeholder="Type"></v-select></p>
+      <panel :type="type">
+        <h4 class="panel-title" slot="header">Panel #1</h4>
+        <strong>Panel with heading slot.</strong> Ut enim ad minim veniam,
+        quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+        cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+        proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      </panel>
+      <panel :type="type" header="Panel #2">
+        <strong>Panel with heading slot.</strong> Ut enim ad minim veniam,
+        quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+        cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+        proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      </panel>
+      <panel :type="type">
+        <strong>Panel without heading.</strong> Ut enim ad minim veniam,
+        quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+        cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+        proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      </panel>
+    </div>
+    <doc-code language="markup">
+      &lt;panel type="primary">
+        &lt;h4 class="panel-title" slot="header">Panel #1&lt;/h4>
+        &lt;strong>Panel with header slot.&lt;strong> ...
+      &lt;/panel>
+
+      &lt;panel type="primary" header="Panel #2">
+        &lt;strong>Panel with header property.&lt;strong> ...
+      &lt;/panel>
+
+      &lt;panel type="primary">
+        &lt;strong>Panel without heading property.&lt;strong> ...
+      &lt;/panel>
+
+    </doc-code>
+    <doc-table>
+      <div>
+        <p>header</p>
+        <p><code>String</code></p>
+        <p></p>
+        <p>The text to be displayed in panel header.</p>
+      </div>
+      <div>
+        <p>is-open</p>
+        <p><code>Boolean</code></p>
+        <p><code>true (if not in accordion group)</code></p>
+        <p>Only applies if panel is in an accordion group.</p>
+      </div>
+      <div>
+        <p>type</p>
+        <p><code>String</code></p>
+        <p><code>null</code></p>
+        <p>Define the type of color for the header</p>
+      </div>
+    </doc-table>
+    <p>
+      If you want to personalise your header with some html you can use the slot instead of header
+      attribute (panel&nbsp;#1 in the example). If no header property or slot is
+      defined and the panel is not nested in an accordion, the header will be hidden.
+    </p>
+    <p>See <a href="#accordion">Accordion</a> for more options.</p>
+  </doc-section>
+</template>
+
+<script>
+import docSection from './utils/docSection.vue'
+import docTable from './utils/docTable.js'
+import docCode from './utils/docCode.js'
+import Panel from 'src/Panel.vue'
+import vSelect from 'src/Select.vue'
+
+export default {
+  components: {
+    docSection,
+    docTable,
+    docCode,
+    Panel,
+    vSelect
+  },
+  data () {
+    return {
+      type: 'default',
+      types: ['default', 'primary', 'info', 'success', 'warning', 'danger']
+    }
+  }
+}
+</script>

--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="['panel',panelType]">
-    <div :class="['panel-heading',{'accordion-toggle':inAccordion}]" @click.prevent="inAccordion&&toggle()">
+    <div :class="['panel-heading',{'accordion-toggle':inAccordion}]" @click.prevent="inAccordion&&toggle()" v-if="showHeader">
       <slot name="header"><h4 class="panel-title">{{ header }}</h4></slot>
     </div>
     <transition
@@ -37,6 +37,7 @@ export default {
   },
   computed: {
     inAccordion () { return this.$parent && this.$parent._isAccordion },
+    showHeader () { return this.inAccordion || this.header || this.$slots.header},
     panelType () { return 'panel-' + (this.type || (this.$parent && this.$parent.type) || 'default') }
   },
   methods: {


### PR DESCRIPTION
- Removes panel heading if the panel is not nested in an accordion and has neither header property nor slot
- Adds a Panel documentation page


Currently, there is no way to create a Panel without a header. This is a common use case that has
and example in the Bootstrap documentation itself.


This only applies to v2 branch


- While this could resolve #21, it only applies to v2