### PR TITLE
Emit PanelClosed and PanelOpened events.

### DIFF
--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -42,6 +42,13 @@ export default {
   methods: {
     toggle () {
       this.open = !this.open
+      
+      if (this.open) {
+          this.$emit('PanelOpened', this);
+      } else {
+          this.$emit('PanelClosed', this);
+      }
+
       if (this.inAccordion) {
         this.$parent.openChild(this)
       }


### PR DESCRIPTION
It might be useful for other components to get the information that a panel has been opened or closed. 

My usecase is to trigger an ajax call to a remote API when a panel get closed.