### PR TITLE
Add events to accordion when panel opens and closes.

### DIFF
--- a/src/Accordion.vue
+++ b/src/Accordion.vue
@@ -21,8 +21,9 @@ export default {
     openChild (child) {
       if (this.oneAtAtime) {
         this.$children.forEach(item => {
-          if (child !== item) {
-            item.open = false
+          if (child !== item && item.open) {
+            item.open = false;
+            this.$emit('panel-closed', this);
           }
         })
       }

--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -42,7 +42,14 @@ export default {
   methods: {
     toggle () {
       this.open = !this.open
+
       if (this.inAccordion) {
+        if (this.open) {
+          this.$parent.$emit('panel-opened', this);
+        } else {
+          this.$parent.$emit('panel-closed', this);
+        }
+
         this.$parent.openChild(this)
       }
     },


### PR DESCRIPTION
It would be nice if an accordion has knowledge when one of its panels opens
or closes and which panel it is.

My usecase is that I want to send an AJAX request when a panel get closed.

With the following implementation the open and closed event on the panel will pushed to
the accordion component if the panel is within an accordion.

The closed event on the accordion component will be fired when an open panel got closed
by opening another panel.