### PR TITLE
@click -> @focus to handle keyboard users (tab)

### DIFF
--- a/src/Datepicker.vue
+++ b/src/Datepicker.vue
@@ -5,7 +5,7 @@
       :class="{'with-reset-button': clearButton}"
       :placeholder="placeholder"
       :style="{width:width}"
-      @click="inputClick"
+      @focus="inputClick"
     />
     <button v-if="clearButton&&val" type="button" class="close" @click="val = ''">
       <span>&times;</span>


### PR DESCRIPTION
I find this behaviour is preferable to the current default. Otherwise I've had instances where people use tab to fill out a form.. and once they tab into the datepicker field since the calendar doesn't appear they start typing.. and still there is nothing to catch this unwanted behaviour or encourage the user to click on the field in order to make the picker appear. It leads to confused users and failed form submittals a plenty