### PR TITLE
Initial value for Input component bug fix.

### DIFF
--- a/src/Input.vue
+++ b/src/Input.vue
@@ -19,6 +19,7 @@
         :title="attr(title)"
         :type="type=='textarea'?null:type"
         v-model="val"
+        :value="value"
         @blur="emit" @focus="emit" @input="emit"
         @keyup.enter="type!='textarea'&&enterSubmit&&submit()"
       ></textarea>
@@ -47,6 +48,7 @@
         :title="attr(title)"
         :type="type=='textarea'?null:type"
         v-model="val"
+        :value="value"
         @blur="emit" @focus="emit" @input="emit"
         @keyup.enter="type!='textarea'&&enterSubmit&&submit()"
       ></textarea>


### PR DESCRIPTION
Without setting the 'value' dynamically prop, the model binding is one way only and can't be initialised with any value.