### PR TITLE
Update Typeahead.vue Key is reserved

### DIFF
--- a/src/Typeahead.vue
+++ b/src/Typeahead.vue
@@ -59,7 +59,7 @@ export default {
       type: String,
       default: 'default'
     },
-    key: {
+    keyStrap: {
       type: String,
       default: null
     },
@@ -128,7 +128,7 @@ export default {
     },
     query: delayer(function () {
       getJSON(this.async + this.value).then(data => {
-        this.items = (this.key ? data[this.key] : data).slice(0, this.limit)
+        this.items = (this.keyStrap ? data[this.keyStrap] : data).slice(0, this.limit)
         this.showDropdown = this.items.length
       })
     }, 'delay', _DELAY_),


### PR DESCRIPTION
I made this changes in one of my projects since i was having this error and I fixed the problem
[Vue warn]: "key" is a reserved attribute and cannot be used as component prop.